### PR TITLE
Revert "Capture yum output on prep & apply.  Partial fix for #27."

### DIFF
--- a/auter
+++ b/auter
@@ -118,7 +118,7 @@ function prepare_updates() {
           fi
           DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
         fi
-        PREPOUTPUT=$(${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y &>${DATADIR}/last-prep-yum-output-${CONFIGSET})
+        PREPOUTPUT=$(${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y)
         if [[ "${ONLYINSTALLFROMPREP}" == "yes" && "${PACKAGE_MANAGER}" == "dnf" ]]; then
           find /var/cache/dnf -name *.rpm -exec mv {} ${DOWNLOADDIR}/${CONFIGSET} \;
         fi
@@ -166,7 +166,7 @@ function apply_updates() {
 
     # We don't want to allow the user to interrupt a yum/dnf transaction or Bad Things Happen.
     trap '' SIGINT SIGTERM
-    ${PACKAGE_MANAGER} ${UPDATEACTION} -y ${PACKAGEMANAGEROPTIONS} ${RPMS} &>${DATADIR}/last-apply-yum-output-${CONFIGSET}
+    ${PACKAGE_MANAGER} ${UPDATEACTION} -y ${PACKAGEMANAGEROPTIONS} ${RPMS} &>/dev/null
     ${PACKAGE_MANAGER} history info > ${DATADIR}/last-update-${CONFIGSET}
     default_signal_handling
 


### PR DESCRIPTION
Reverts rackerlabs/auter#34

Actually this does not work... In line 121 we are assigning the output to a variable so by redirecting the output the variable is left empty. We should either tee the output or add a new line to
```
echo ${PREPOUTPUT} > ${DATADIR}/last-prep-yum-output-${CONFIGSET}
```