### PR TITLE
Removes last-update file since it's unnecessary and named misleadingly.

### DIFF
--- a/auter
+++ b/auter
@@ -166,7 +166,6 @@ function apply_updates() {
     # We don't want to allow the user to interrupt a yum/dnf transaction or Bad Things Happen.
     trap '' SIGINT SIGTERM
     ${PACKAGE_MANAGER} ${UPDATEACTION} -y ${PACKAGEMANAGEROPTIONS} ${RPMS} &>/dev/null
-    ${PACKAGE_MANAGER} history info > ${DATADIR}/last-update-${CONFIGSET}
     default_signal_handling
 
     local HISTORY_AFTER=$(${PACKAGE_MANAGER} history list)
@@ -176,7 +175,7 @@ function apply_updates() {
       quit 3
     fi
   
-    local TRANSACTIONID=$(grep "Transaction ID" ${DATADIR}/last-update-${CONFIGSET})
+    local TRANSACTIONID=$(yum history info 2>&1 | grep "Transaction ID")
     logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
 
     for SCRIPT in "${POSTAPPLYSCRIPTDIR}"/*; do

--- a/auter.help2man
+++ b/auter.help2man
@@ -21,9 +21,6 @@
 \//var/lib/auter/last-apply-yum-output-CONFIGSET
   This file contains the output from the yum command that was run during the last time auter was invoked with --apply. There may be multiple logs if different config files are used. This file will be updated/created every time auter --apply is run. The CONFIGSET part of the filename is defined in the auter config file by setting a variable of the same name, and if not defined is set to "default".
 
-\//var/lib/auter/last-update-CONFIGSET
-  This file contains the output from the last successful yum update which was run on the machine (whether applied by auter or not). The CONFIGSET part of the filename is defined in the auter config file by setting a variable of the same name, and if not defined is set to "default".
-
 \//etc/auter/pre-apply.d/
 \//etc/auter/post-apply.d/
 \//etc/auter/pre-reboot.d/


### PR DESCRIPTION
All of the information from this file can be retrieved from yum history.
Fixes #23.