### PR TITLE
Single redhat module for splitting auter to support different distributions

### DIFF
--- a/auter
+++ b/auter
@@ -24,7 +24,6 @@ readonly SCRIPTDIR="/etc/auter"
 readonly DATADIR="/var/lib/auter"
 readonly LOCKFILE="${DATADIR}/enabled"
 readonly PIDFILE="/var/run/auter/auter.pid"
-readonly FUNCTIONDIR="/usr/lib/auter"
 
 # Set default options - these can be overridden in the config file or with a command line argument
 AUTOREBOOT="no"
@@ -94,20 +93,10 @@ function check_package_manager() {
     echo dnf
   elif [[ -x /usr/bin/yum ]]; then
     echo yum
-  elif [[ -x /usr/bin/apt-get ]]; then
-    echo apt-get
   else
-    logit "ERROR: Cannot find yum, dnf or apt-get"
+    logit "ERROR: Cannot find yum or dnf"
     exit 7
   fi
-}
-
-function prepare_updates() {
-  . ${FUNCTIONDIR}/auter.module prepare_updates
-}
-
-function apply_updates() {
-  . ${FUNCTIONDIR}/auter.module apply_updates
 }
 
 function reboot_server() {
@@ -262,8 +251,12 @@ $(tty -s) && MAXDELAY=1 && logit "INFO: Running in an interactive shell, disabli
 
 [[ "${POSTREBOOT}" ]] && post_reboot && quit 0
 
+# Source the module for the specific OS distribution
+. /usr/lib/auter/auter.module
+# The following 2 functions are provided by the previously sourced /usr/lib/auter/auter.module
 [[ "${PREP}" ]] && prepare_updates
 [[ "${APPLY}" ]] && apply_updates
+
 [[ "${REBOOTCALL}" ]] && reboot_server
 
 quit 0

--- a/auter
+++ b/auter
@@ -251,7 +251,7 @@ $(tty -s) && MAXDELAY=1 && logit "INFO: Running in an interactive shell, disabli
 
 [[ "${POSTREBOOT}" ]] && post_reboot && quit 0
 
-# Source the module for the specific OS distribution
+# Source the module for the specific package manager.
 . /usr/lib/auter/auter.module
 # The following 2 functions are provided by the previously sourced /usr/lib/auter/auter.module
 [[ "${PREP}" ]] && prepare_updates

--- a/auter
+++ b/auter
@@ -24,6 +24,7 @@ readonly SCRIPTDIR="/etc/auter"
 readonly DATADIR="/var/lib/auter"
 readonly LOCKFILE="${DATADIR}/enabled"
 readonly PIDFILE="/var/run/auter/auter.pid"
+readonly FUNCTIONDIR="/usr/lib/auter"
 
 # Set default options - these can be overridden in the config file or with a command line argument
 AUTOREBOOT="no"
@@ -93,109 +94,20 @@ function check_package_manager() {
     echo dnf
   elif [[ -x /usr/bin/yum ]]; then
     echo yum
+  elif [[ -x /usr/bin/apt-get ]]; then
+    echo apt-get
   else
-    logit "ERROR: Cannot find yum or dnf"
+    logit "ERROR: Cannot find yum, dnf or apt-get"
     exit 7
   fi
 }
 
 function prepare_updates() {
-  if [[ "${PREDOWNLOADUPDATES}" == "yes" ]]; then
-    if [[ $(${PACKAGE_MANAGER} --help | grep -c downloadonly) -gt 0 ]]; then
-      local RC=$(${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS} &>/dev/null; echo $?)
-
-      # If check-update has an exit code of 100, updates are available.
-      if [[ "${RC}" -eq 100 ]]; then
-        sleep $(($RANDOM % ${MAXDELAY}))
-        if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
-          DOWNLOADOPTION="--downloaddir=${DOWNLOADDIR}/${CONFIGSET}"
-          rm -f "${DOWNLOADDIR}"/"${CONFIGSET}"/*.rpm
-          # DNF doesn't support downloaddir, so instead we download to the default
-          # location and copy out the way
-          if [[ "${PACKAGE_MANAGER}" == "dnf" ]]; then
-            find /var/cache/dnf -name *.rpm -exec rm -f {} \;
-            DOWNLOADOPTION=""
-          fi
-          DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
-        fi
-
-        ${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y &>${DATADIR}/last-prep-yum-output-${CONFIGSET}
-        if [[ $? -eq 0 ]]; then
-          if [[ "${ONLYINSTALLFROMPREP}" == "yes" && "${PACKAGE_MANAGER}" == "dnf" ]]; then
-            find /var/cache/dnf -name *.rpm -exec mv {} ${DOWNLOADDIR}/${CONFIGSET} \;
-          fi
-          logit "INFO: Updates downloaded${DOWNLOADLOGMSG}"
-        else
-          logit "ERROR: Updates could not be pre-downloaded${DOWNLOADLOGMSG}. See the ${DATADIR}/last-prep-yum-output-${CONFIGSET} file for details."
-        fi
-
-      elif [[ "${RC}" -eq 1 ]]; then
-        logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y\`. Exiting."
-      else
-        logit "INFO: No updates are available to be downloaded."
-      fi
-    else
-      logit "WARNING: downloadonly option is not available"
-    fi
-  else
-    ${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} check-update &>${DATADIR}/last-prep-yum-output-${CONFIGSET}
-  fi
+  . ${FUNCTIONDIR}/auter.module prepare_updates
 }
 
 function apply_updates() {
-  # Set the list of rpms to be installed
-  if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
-    RC=0
-    if [[ $(ls -1 ${DOWNLOADDIR}/${CONFIGSET}/*.rpm | wc -l) -gt 0 ]]; then
-      RPMS="${DOWNLOADDIR}/${CONFIGSET}/*.rpm"
-      RC=100
-    fi
-    # When passing RPMs to dnf/yum, the update verb won't install any that aren't already
-    # installed (i.e. dependencies of other packages). Instead we need to use install.
-    UPDATEACTION="install"
-  else
-    local RC=$(${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS} &>/dev/null; echo $?)
-    UPDATEACTION="update"
-  fi
-
-  # If check-update has an exit code of 100, updates are available.
-  if [[ "${RC}" -eq 100 ]]; then
-    for SCRIPT in "${PREAPPLYSCRIPTDIR}"/*; do
-      run_script "${SCRIPT}" "Pre-Apply"
-    done
-  
-    sleep $(($RANDOM % ${MAXDELAY}))
-    logit "INFO: Applying updates"
-    local HISTORY_BEFORE=$(${PACKAGE_MANAGER} history list)
-
-    # We don't want to allow the user to interrupt a yum/dnf transaction or Bad Things Happen.
-    trap '' SIGINT SIGTERM
-    ${PACKAGE_MANAGER} ${UPDATEACTION} -y ${PACKAGEMANAGEROPTIONS} ${RPMS} &>${DATADIR}/last-apply-yum-output-${CONFIGSET}
-    default_signal_handling
-
-    local HISTORY_AFTER=$(${PACKAGE_MANAGER} history list)
-  
-    if [[ "${HISTORY_BEFORE}" == "${HISTORY_AFTER}" ]]; then 
-      logit "ERROR: Updates failed. Exiting."
-      quit 3
-    fi
-  
-    local TRANSACTIONID=$(yum history info 2>&1 | grep "Transaction ID")
-    logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
-
-    for SCRIPT in "${POSTAPPLYSCRIPTDIR}"/*; do
-      run_script "${SCRIPT}" "Post-Apply"
-    done
-
-    [[ "${AUTOREBOOT}" == "yes" ]] && reboot_server
-
-  elif [[ "${RC}" -eq 0 ]]; then
-    logit "INFO: No updates are available to be applied."
-    quit 0
-  else
-    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS}\`. Exiting."
-    quit 3
-  fi
+  . ${FUNCTIONDIR}/auter.module apply_updates
 }
 
 function reboot_server() {

--- a/auter.redhatModule
+++ b/auter.redhatModule
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# This is a script that is intended to only be called by /usr/bin/auter and 
+# contains linux distribution specifc code for auter. 
+
+
+# This is the redhat/fedora/CentOS version of this script
+
+function prepare_updates() {
+  if [[ "${PREDOWNLOADUPDATES}" == "yes" ]]; then
+    if [[ $(${PACKAGE_MANAGER} --help | grep -c downloadonly) -gt 0 ]]; then
+      local RC=$(${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS} &>/dev/null; echo $?)
+
+      # If check-update has an exit code of 100, updates are available.
+      if [[ "${RC}" -eq 100 ]]; then
+        sleep $(($RANDOM % ${MAXDELAY}))
+        if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
+          DOWNLOADOPTION="--downloaddir=${DOWNLOADDIR}/${CONFIGSET}"
+          rm -f "${DOWNLOADDIR}"/"${CONFIGSET}"/*.rpm
+          # DNF doesn't support downloaddir, so instead we download to the default
+          # location and copy out the way
+          if [[ "${PACKAGE_MANAGER}" == "dnf" ]]; then
+            find /var/cache/dnf -name *.rpm -exec rm -f {} \;
+            DOWNLOADOPTION=""
+          fi
+          DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
+        fi
+
+        ${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y &>${DATADIR}/last-prep-yum-output-${CONFIGSET}
+        if [[ $? -eq 0 ]]; then
+          if [[ "${ONLYINSTALLFROMPREP}" == "yes" && "${PACKAGE_MANAGER}" == "dnf" ]]; then
+            find /var/cache/dnf -name *.rpm -exec mv {} ${DOWNLOADDIR}/${CONFIGSET} \;
+          fi
+          logit "INFO: Updates downloaded${DOWNLOADLOGMSG}"
+        else
+          logit "ERROR: Updates could not be pre-downloaded${DOWNLOADLOGMSG}. See the ${DATADIR}/last-prep-yum-output-${CONFIGSET} file for details."
+        fi
+
+      elif [[ "${RC}" -eq 1 ]]; then
+        logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y\`. Exiting."
+      else
+        logit "INFO: No updates are available to be downloaded."
+      fi
+    else
+      logit "WARNING: downloadonly option is not available"
+    fi
+  else
+    ${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} check-update &>${DATADIR}/last-prep-yum-output-${CONFIGSET}
+  fi
+}
+
+function apply_updates() {
+  # Set the list of rpms to be installed
+  if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
+    RC=0
+    if [[ $(ls -1 ${DOWNLOADDIR}/${CONFIGSET}/*.rpm | wc -l) -gt 0 ]]; then
+      RPMS="${DOWNLOADDIR}/${CONFIGSET}/*.rpm"
+      RC=100
+    fi
+    # When passing RPMs to dnf/yum, the update verb won't install any that aren't already
+    # installed (i.e. dependencies of other packages). Instead we need to use install.
+    UPDATEACTION="install"
+  else
+    local RC=$(${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS} &>/dev/null; echo $?)
+    UPDATEACTION="update"
+  fi
+
+  # If check-update has an exit code of 100, updates are available.
+  if [[ "${RC}" -eq 100 ]]; then
+    for SCRIPT in "${PREAPPLYSCRIPTDIR}"/*; do
+      run_script "${SCRIPT}" "Pre-Apply"
+    done
+
+    sleep $(($RANDOM % ${MAXDELAY}))
+    logit "INFO: Applying updates"
+    local HISTORY_BEFORE=$(${PACKAGE_MANAGER} history list)
+
+    # We don't want to allow the user to interrupt a yum/dnf transaction or Bad Things Happen.
+    trap '' SIGINT SIGTERM
+    ${PACKAGE_MANAGER} ${UPDATEACTION} -y ${PACKAGEMANAGEROPTIONS} ${RPMS} &>${DATADIR}/last-apply-yum-output-${CONFIGSET}
+    default_signal_handling
+
+    local HISTORY_AFTER=$(${PACKAGE_MANAGER} history list)
+
+    if [[ "${HISTORY_BEFORE}" == "${HISTORY_AFTER}" ]]; then
+      logit "ERROR: Updates failed. Exiting."
+      quit 3
+    fi
+
+    local TRANSACTIONID=$(yum history info 2>&1 | grep "Transaction ID")
+    logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
+
+    for SCRIPT in "${POSTAPPLYSCRIPTDIR}"/*; do
+      run_script "${SCRIPT}" "Post-Apply"
+    done
+
+    [[ "${AUTOREBOOT}" == "yes" ]] && reboot_server
+
+  elif [[ "${RC}" -eq 0 ]]; then
+    logit "INFO: No updates are available to be applied."
+    quit 0
+  else
+    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS}\`. Exiting."
+    quit 3
+  fi
+}
+
+[[ ! $1 ]] && exit 1
+[[ $1 == "prepare_updates" ]] && prepare_updates
+[[ $1 == "apply_updates" ]] && prepare_updates

--- a/auter.spec
+++ b/auter.spec
@@ -49,7 +49,7 @@ mkdir -p %{buildroot}%{_bindir} %{buildroot}%{_sharedstatedir}/%{name} \
   %{buildroot}%{_sysconfdir}/%{name}/post-apply.d
 
 install -p -m 0755 %{name} %{buildroot}%{_bindir}
-install -p -m 0755 %{name}.yumdnfModule %{buildroot}%{_usr}/lib/%{name}.module
+install -p -m 0755 %{name}.yumdnfModule %{buildroot}%{_usr}/lib/%{name}/auter.module
 install -p -m 0644 %{name}.cron %{buildroot}%{_sysconfdir}/cron.d/%{name}
 install -p -m 0644 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}/%{name}.conf
 install -p -m 0644 %{name}.man %{buildroot}%{_mandir}/man1/%{name}.1
@@ -88,7 +88,7 @@ exit 0
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 %{_bindir}/%{name}
-%{_usr}/lib/%{name}.module
+%{_usr}/lib/%{name}/auter.module
 %if 0%{?el6}
 %dir %{_localstatedir}/run/%{name}/
 %ghost %{_localstatedir}/run/%{name}/%{name}.pid

--- a/auter.spec
+++ b/auter.spec
@@ -41,6 +41,7 @@ touch %{buildroot}%{_localstatedir}/run/%{name}/%{name}.pid
 mkdir -p %{buildroot}%{_bindir} %{buildroot}%{_sharedstatedir}/%{name} \
   %{buildroot}%{_sysconfdir}/cron.d %{buildroot}%{_sysconfdir}/%{name} \
   %{buildroot}%{_var}/cache/auter \
+  %{buildroot}%{_usr}/lib/%{name} \
   %{buildroot}%{_mandir}/man1 \
   %{buildroot}%{_sysconfdir}/%{name}/pre-reboot.d \
   %{buildroot}%{_sysconfdir}/%{name}/post-reboot.d \
@@ -48,6 +49,7 @@ mkdir -p %{buildroot}%{_bindir} %{buildroot}%{_sharedstatedir}/%{name} \
   %{buildroot}%{_sysconfdir}/%{name}/post-apply.d
 
 install -p -m 0755 %{name} %{buildroot}%{_bindir}
+install -p -m 0755 %{name}.redhatModule %{buildroot}%{_usr}/lib/%{name}.module
 install -p -m 0644 %{name}.cron %{buildroot}%{_sysconfdir}/cron.d/%{name}
 install -p -m 0644 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}/%{name}.conf
 install -p -m 0644 %{name}.man %{buildroot}%{_mandir}/man1/%{name}.1
@@ -82,9 +84,11 @@ exit 0
 %dir %{_sysconfdir}/%{name}/post-reboot.d
 %dir %{_sysconfdir}/%{name}/pre-apply.d
 %dir %{_sysconfdir}/%{name}/post-apply.d
+%dir %{_usr}/lib/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/cron.d/%{name}
 %{_bindir}/%{name}
+%{_usr}/lib/%{name}.module
 %if 0%{?el6}
 %dir %{_localstatedir}/run/%{name}/
 %ghost %{_localstatedir}/run/%{name}/%{name}.pid
@@ -95,6 +99,11 @@ exit 0
 %endif
 
 %changelog
+* Mon Jan 30 2017 Paolo Gigante <paolo.gigante@rackspace.co.uk> 0.1-1
+- Release version 0.9
+- Moved prep and apply functions to separate script /usr/lib/auter/auter.module
+- 
+
 * Mon Nov 14 2016 Piers Cornwell <piers.cornwell@rackspace.co.uk> 0.8-1
 - Release version 0.8
 - Added ONLYINSTALLFROMPREP option

--- a/auter.spec
+++ b/auter.spec
@@ -49,7 +49,7 @@ mkdir -p %{buildroot}%{_bindir} %{buildroot}%{_sharedstatedir}/%{name} \
   %{buildroot}%{_sysconfdir}/%{name}/post-apply.d
 
 install -p -m 0755 %{name} %{buildroot}%{_bindir}
-install -p -m 0755 %{name}.redhatModule %{buildroot}%{_usr}/lib/%{name}.module
+install -p -m 0755 %{name}.yumdnfModule %{buildroot}%{_usr}/lib/%{name}.module
 install -p -m 0644 %{name}.cron %{buildroot}%{_sysconfdir}/cron.d/%{name}
 install -p -m 0644 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}/%{name}.conf
 install -p -m 0644 %{name}.man %{buildroot}%{_mandir}/man1/%{name}.1

--- a/auter.spec
+++ b/auter.spec
@@ -99,11 +99,6 @@ exit 0
 %endif
 
 %changelog
-* Mon Jan 30 2017 Paolo Gigante <paolo.gigante@rackspace.co.uk> 0.1-1
-- Release version 0.9
-- Moved prep and apply functions to separate script /usr/lib/auter/auter.module
-- 
-
 * Mon Nov 14 2016 Piers Cornwell <piers.cornwell@rackspace.co.uk> 0.8-1
 - Release version 0.8
 - Added ONLYINSTALLFROMPREP option

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -1,10 +1,13 @@
-#!/bin/bash
-
 # This is a script that is intended to only be called by /usr/bin/auter and 
 # contains linux distribution specifc code for auter. 
 
 
 # This is the redhat/fedora/CentOS version of this script
+
+# Exit if this script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "ERROR: This script is used by auter and should not be executed directly. Exiting"
+fi
 
 function prepare_updates() {
   if [[ "${PREDOWNLOADUPDATES}" == "yes" ]]; then
@@ -87,7 +90,7 @@ function apply_updates() {
       quit 3
     fi
 
-    local TRANSACTIONID=$(yum history info 2>&1 | grep "Transaction ID")
+    local TRANSACTIONID=$(${PACKAGE_MANAGER} history info 2>&1 | grep "Transaction ID")
     logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
 
     for SCRIPT in "${POSTAPPLYSCRIPTDIR}"/*; do
@@ -104,7 +107,3 @@ function apply_updates() {
     quit 3
   fi
 }
-
-[[ ! $1 ]] && exit 1
-[[ $1 == "prepare_updates" ]] && prepare_updates
-[[ $1 == "apply_updates" ]] && prepare_updates

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -1,8 +1,8 @@
 # This is a script that is intended to only be called by /usr/bin/auter and 
-# contains linux distribution specifc code for auter. 
+# contains linux pagage manager specifc code for auter. 
 
 
-# This is the redhat/fedora/CentOS version of this script
+# This is the yum/dnf version of this script intended for redhat/fedora/CentOS 
 
 # Exit if this script is executed directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
This is a simplification of #32 which only includes the redhat module. This is becoming more difficult to maintain as changes are being made in the master branch before this is merged. The only change here is that the prepare_updates and apply_updates have been moved to a separate script. This means that in future, we can build more modules for other distributions if required.
