### PR TITLE
Clarify documentation around when scripts are run.

### DIFF
--- a/auter.conf
+++ b/auter.conf
@@ -7,7 +7,9 @@ CONFIGSET="default"
 
 # Set whether server will reboot automatically after --apply. A warning
 # message will show for logged in users 2 mins before the reboot. The 
-# system will only be rebooted if an update was applied.
+# system will only be rebooted if one or more updates were applied
+# successfully, and if all of the custom pre-apply, post-apply and pre-reboot 
+# scripts exit with a non-zero exit code.
 AUTOREBOOT="no"
 
 # Options to pass to yum/dnf update. For example, this can be used to 
@@ -37,7 +39,10 @@ ONLYINSTALLFROMPREP="no"
 MAXDELAY="3600"
 
 # Directories containing scripts to execute before/after updates are applied, 
-# and before/after a reboot (if applicable)
+# and before/after a reboot (if applicable). Scripts in these directories must
+# be executable (+x) for auter to run them. If any pre/post scripts run by auter 
+# exit with a non-zero exit code, auter will exit immediately before running
+# any further actions.
 PREAPPLYSCRIPTDIR="/etc/auter/pre-apply.d"
 POSTAPPLYSCRIPTDIR="/etc/auter/post-apply.d"
 PREREBOOTSCRIPTDIR="/etc/auter/pre-reboot.d"

--- a/auter.help2man
+++ b/auter.help2man
@@ -50,7 +50,7 @@ Config options are set in /etc/auter/auter.conf, or in the file referenced by th
  AUTOREBOOT
  Valid options: "yes" or "no"
  Default: "no"
- If set to "yes" the server will be rebooted 2 minutes after applying updates
+ If set to "yes" the server will be rebooted 2 minutes after successfully applying updates. If updates are not applied successfully, auter will exit and a reboot will NOT occur.
 
  PACKAGEMANAGEROPTIONS
  Valid options: Any valid yum or dnf options can be specified (including dashes). This is passed directly to the package manager.
@@ -73,22 +73,22 @@ Config options are set in /etc/auter/auter.conf, or in the file referenced by th
  This is the upper limit in seconds of a random time to wait before querying repositories.
 
  PREAPPLYSCRIPTDIR
- Valid options: path to directory containing scripts
+ Valid options: path to directory containing executable scripts
  Default: "/etc/auter/pre-apply.d"
- Custom scripts to be run before applying updates
+ Custom scripts to be run before applying updates. If any of the scripts in this directory exit with a non-zero error code, auter will exit immediately before applying updates.
 
  POSTAPPLYSCRIPTDIR
- Valid options: path to directory containing scripts
+ Valid options: path to directory containing executable scripts
  Default: "/etc/auter/post-apply.d"
- Custom scripts to be run after applying updates
+ Custom scripts to be run after applying updates. If any of the scripts in this directory exit with a non-zero exit code, auter will exit immediately before triggering a reboot.
 
  PREREBOOTSCRIPTDIR
- Valid options: path to directory containing scripts
+ Valid options: path to directory containing executable scripts
  Default: "/etc/auter/pre-reboot.d"
- Custom scripts to be run before rebooting. These will only run if AUTOREBOOT="yes" or auter is run with the --reboot option
+ Custom scripts to be run before rebooting. These will only run if AUTOREBOOT="yes" or auter is run with the --reboot option. If any of the scripts in this directory exit with a non-zero exit code, auter will exit immediately before triggering a reboot.
 
  POSTREBOOTSCRIPTDIR
- Valid options: path to directory containing scripts
+ Valid options: path to directory containing executable scripts
  Default: "/etc/auter/post-reboot.d"
  Custom scripts to be run after rebooting. These will only run if AUTOREBOOT="yes" or auter is run with the --reboot option
 

--- a/auter.help2man
+++ b/auter.help2man
@@ -85,12 +85,12 @@ Config options are set in /etc/auter/auter.conf, or in the file referenced by th
  PREREBOOTSCRIPTDIR
  Valid options: path to directory containing executable scripts
  Default: "/etc/auter/pre-reboot.d"
- Custom scripts to be run before rebooting. These will only run if AUTOREBOOT="yes" or auter is run with the --reboot option. If any of the scripts in this directory exit with a non-zero exit code, auter will exit immediately before triggering a reboot.
+ Custom scripts to be run before rebooting. These will only run if updates are applied successfully, and either AUTOREBOOT="yes" or auter is run with the --reboot option. If any of the scripts in this directory exit with a non-zero exit code, auter will exit immediately before triggering a reboot.
 
  POSTREBOOTSCRIPTDIR
  Valid options: path to directory containing executable scripts
  Default: "/etc/auter/post-reboot.d"
- Custom scripts to be run after rebooting. These will only run if AUTOREBOOT="yes" or auter is run with the --reboot option
+ Custom scripts to be run after rebooting. These will run after an auter-initiated reboot if AUTOREBOOT="yes" or auter is run with the --reboot option
 
 [Exit Codes]
 

--- a/auter.help2man
+++ b/auter.help2man
@@ -80,7 +80,7 @@ Config options are set in /etc/auter/auter.conf, or in the file referenced by th
  POSTAPPLYSCRIPTDIR
  Valid options: path to directory containing executable scripts
  Default: "/etc/auter/post-apply.d"
- Custom scripts to be run after applying updates. If any of the scripts in this directory exit with a non-zero exit code, auter will exit immediately before triggering a reboot.
+ Custom scripts to be run after applying updates. Scripts in this directory will run regardless of whether updates were applied successfully or not.  If any of the scripts in this directory exit with a non-zero exit code, auter will exit immediately before triggering a reboot.
 
  PREREBOOTSCRIPTDIR
  Valid options: path to directory containing executable scripts


### PR DESCRIPTION
Clarify behaviour when pre/post scripts exit with a non-zero exit code.

Fixes #54 