### PR TITLE
Specifically log the time that Auter last ran

### DIFF
--- a/auter
+++ b/auter
@@ -145,6 +145,11 @@ function quit() {
   exit $1
 }
 
+function log_last_run() {
+    local LASTRUNTIME=$(date -Iseconds)
+    logit "INFO: Auter last run time: ${LASTRUNTIME}"
+}
+
 
 # Main
 

--- a/auter
+++ b/auter
@@ -147,7 +147,7 @@ function quit() {
 
 function log_last_run() {
     local LASTRUNTIME=$(date -Iseconds)
-    logit "INFO: Auter last run time: ${LASTRUNTIME}"
+    logit "INFO: Auter successfully ran at ${LASTRUNTIME}"
 }
 
 

--- a/auter.aptModule
+++ b/auter.aptModule
@@ -113,6 +113,7 @@ echo "This message should not print"
 
     else
       logit "INFO: No updates are available to be applied."
+      log_last_run
     fi
   else
     logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS}\`. Exiting."

--- a/auter.aptModule
+++ b/auter.aptModule
@@ -103,6 +103,7 @@ echo "This message should not print"
       fi
 
       logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
+      log_last_run
 
       for SCRIPT in "${POSTAPPLYSCRIPTDIR}"/*; do
         run_script "${SCRIPT}" "Post-Apply"

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -119,6 +119,7 @@ function apply_updates() {
 
   elif [[ "${RC}" -eq 0 ]]; then
     logit "INFO: No updates are available to be applied."
+    log_last_run
   else
     logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS}\`. Exiting."
     quit 3

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -113,6 +113,7 @@ function apply_updates() {
 
     local TRANSACTIONID=$(${PACKAGE_MANAGER} history info 2>&1 | grep "Transaction ID")
     logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
+    log_last_run
 
     [[ "${AUTOREBOOT}" == "yes" ]] && reboot_server
 


### PR DESCRIPTION
Tools, including [auter-audit.sh](https://github.com/rackerlabs/auter-manager/blob/master/reporter/auter-audit.sh)
would like to report the date that Auter last run. It will be much easier to do
this in a standard way if Auter reported (in ISO8601 format) the date/time it
completed.

That way tools can extract the specific time in a known format from the log,
rather than relying on what logging format the server has set in syslog for
its date.

This is my proposal to address Issue #62 