### PR TITLE
Export config options for use in pre/post scripts

### DIFF
--- a/auter
+++ b/auter
@@ -26,13 +26,13 @@ declare -r -x LOCKFILE="${DATADIR}/enabled"
 declare -r -x PIDFILE="/var/run/auter/auter.pid"
 
 # Set default options - these can be overridden in the config file or with a command line argument
-declare -x AUTOREBOOT="no"
+declare -x -l AUTOREBOOT="no"
 declare -x PACKAGEMANAGEROPTIONS=""
-declare -x PREDOWNLOADUPDATES="yes"
-declare -x ONLYINSTALLFROMPREP="no"
+declare -x -l PREDOWNLOADUPDATES="yes"
+declare -x -l ONLYINSTALLFROMPREP="no"
 declare -x CONFIGFILE="/etc/auter/auter.conf"
 declare -x DOWNLOADDIR="/var/cache/auter"
-declare -x MAXDELAY=3600
+declare -x -i MAXDELAY=3600
 declare -x CONFIGSET="default"
 PREPREPSCRIPTDIR="${SCRIPTDIR}/pre-prep.d"
 POSTPREPSCRIPTDIR="${SCRIPTDIR}/post-prep.d"

--- a/auter
+++ b/auter
@@ -19,21 +19,21 @@
 #
 
 
-readonly AUTERVERSION="0.11"
-readonly SCRIPTDIR="/etc/auter"
-readonly DATADIR="/var/lib/auter"
-readonly LOCKFILE="${DATADIR}/enabled"
-readonly PIDFILE="/var/run/auter/auter.pid"
+declare -r -x AUTERVERSION="0.11"
+declare -r -x SCRIPTDIR="/etc/auter"
+declare -r -x DATADIR="/var/lib/auter"
+declare -r -x LOCKFILE="${DATADIR}/enabled"
+declare -r -x PIDFILE="/var/run/auter/auter.pid"
 
 # Set default options - these can be overridden in the config file or with a command line argument
-AUTOREBOOT="no"
-PACKAGEMANAGEROPTIONS=""
-PREDOWNLOADUPDATES="yes"
-ONLYINSTALLFROMPREP="no"
-CONFIGFILE="/etc/auter/auter.conf"
-DOWNLOADDIR="/var/cache/auter"
-MAXDELAY=3600
-CONFIGSET="default"
+declare -x AUTOREBOOT="no"
+declare -x PACKAGEMANAGEROPTIONS=""
+declare -x PREDOWNLOADUPDATES="yes"
+declare -x ONLYINSTALLFROMPREP="no"
+declare -x CONFIGFILE="/etc/auter/auter.conf"
+declare -x DOWNLOADDIR="/var/cache/auter"
+declare -x MAXDELAY=3600
+declare -x CONFIGSET="default"
 PREPREPSCRIPTDIR="${SCRIPTDIR}/pre-prep.d"
 POSTPREPSCRIPTDIR="${SCRIPTDIR}/post-prep.d"
 PREAPPLYSCRIPTDIR="${SCRIPTDIR}/pre-apply.d"
@@ -178,7 +178,7 @@ while true ; do
     -h|--help) print_help ; exit 0; shift;;
     -v|--version) echo "auter ${AUTERVERSION}"; exit 0 ; shift;;
     --stdout) STDOUT=1; shift;;
-    --config) unset CONFIGSET ; CONFIGFILE=$2 ; CUSTOMCONFIG=1 ; shift 2;;
+    --config) unset CONFIGSET ; declare -x CONFIGFILE=$2 ; CUSTOMCONFIG=1 ; shift 2;;
     --prep) PREP=1 ; shift;;
     --apply) APPLY=1 ; shift;;
     --reboot) REBOOTCALL=1 ; shift;;

--- a/auter
+++ b/auter
@@ -175,18 +175,18 @@ eval set -- "$OPTS"
 
 while true ; do
   case "$1" in
-    -h|--help) print_help ; exit 0; shift;;
-    -v|--version) echo "auter ${AUTERVERSION}"; exit 0 ; shift;;
-    --stdout) STDOUT=1; shift;;
-    --config) unset CONFIGSET ; declare -x CONFIGFILE=$2 ; CUSTOMCONFIG=1 ; shift 2;;
+    -h|--help) print_help ; exit 0;;
+    -v|--version) echo "auter ${AUTERVERSION}" ; exit 0;;
+    --stdout) STDOUT=1 ; shift;;
+    --config) CONFIGSET="" ; CONFIGFILE="$2" ; CUSTOMCONFIG=1 ; shift 2;;
     --prep) PREP=1 ; shift;;
     --apply) APPLY=1 ; shift;;
     --reboot) REBOOTCALL=1 ; shift;;
     --postreboot) POSTREBOOT=1 ; shift;;
     --enable) ENABLE=1 ; shift;;
     --disable) DISABLE=1 ; shift;;
-    --status) print_status ; exit 0 ; shift;;
-    --) shift ; break ;;
+    --status) print_status ; exit 0;;
+    --) shift ; break;;
   esac
 done
 


### PR DESCRIPTION
Currently pre/post scripts run via run_script do not inherit the config
from auter - there is no way to know what CONFIGSET/CONFIGFILE are
without sourcing the default config file. If auter is being
run with --config <file> then there is no way to know what options are
set without passing all of them as arguments.

Exporting the config options removes this issue.