### PR TITLE
Remove brackets from argument check

### DIFF
--- a/auter
+++ b/auter
@@ -190,7 +190,7 @@ while true ; do
   esac
 done
 
-[[ "${PREP}${APPLY}${REBOOTCALL}${POSTREBOOT}${ENABLE}${DISABLE}" == "" ]] && (print_help && exit 1)
+[[ "${PREP}${APPLY}${REBOOTCALL}${POSTREBOOT}${ENABLE}${DISABLE}" == "" ]] && print_help && exit 1
 
 readonly PACKAGE_MANAGER=$(check_package_manager)
 

--- a/auter
+++ b/auter
@@ -190,7 +190,7 @@ while true ; do
   esac
 done
 
-[[ "${PREP}${APPLY}${REBOOTCALL}${POSTREBOOT}${ENABLE}${DISABLE}" == "" ]] && print_help && exit 1
+[[ "${PREP}${APPLY}${REBOOTCALL}${POSTREBOOT}${ENABLE}${DISABLE}" == "" ]] && print_help && quit 1
 
 readonly PACKAGE_MANAGER=$(check_package_manager)
 


### PR DESCRIPTION
The (exit 1) will exit the sub-shell instead of the auter process shell.

```
root@centos6a:~ > auter

Usage: auter [--enable|--disable|--status] [--prep] [--apply] [--reboot] [--postreboot] [--config=<configfile>] [OPTION]

Actions:
  --enable      Enable auter
  --disable     Disable auter. Also deletes unused pidfile if it exists
  --status      Show whether enabled or disabled
  --prep        Pre-download updates before applying
  --apply       Apply updates, and reboot if AUTOREBOOT=yes
  --reboot      Reboot system including pre/post reboot scripts
  --postreboot  Run post reboot script

Options:
  --config=FILE Specify the full path to an auter config file. Defaults to /etc/auter/auter.conf
  -h, --help    Show this help text
  -v, --version Show the version

INFO: Running with: /usr/bin/auter
INFO: Running in an interactive shell, disabling all random sleeps
```