### PR TITLE
Empty string being wrapped in '' causing yum to fail

### DIFF
--- a/auter
+++ b/auter
@@ -27,7 +27,7 @@ declare -r -x PIDFILE="/var/run/auter/auter.pid"
 
 # Set default options - these can be overridden in the config file or with a command line argument
 declare -x -l AUTOREBOOT="no"
-declare -x PACKAGEMANAGEROPTIONS=""
+declare -x -a PACKAGEMANAGEROPTIONS
 declare -x -l PREDOWNLOADUPDATES="yes"
 declare -x -l ONLYINSTALLFROMPREP="no"
 declare -x CONFIGFILE="/etc/auter/auter.conf"
@@ -73,6 +73,21 @@ function logit() {
   # If running on a tty, or the --stdout option is provided, print to screen
   ( tty -s || [[ $STDOUT ]] ) && echo "$1"
   logger -p info -t auter "$1"
+}
+
+function read_config() {
+  if [[ -f "${CONFIGFILE}" ]]; then
+    source "${CONFIGFILE}"
+  elif [[ "${CUSTOMCONFIG}" ]]; then
+    logit "ERROR: Custom config file ${CONFIGFILE} does not exist"
+    quit 5
+  else
+    logit "WARNING: Using default config values."
+  fi
+
+  # Convert space separated list from the config file to an indexed array
+  # https://github.com/koalaman/shellcheck/wiki/SC2086
+  PACKAGEMANAGEROPTIONS=($PACKAGEMANAGEROPTIONS)
 }
 
 function rotate_file {
@@ -256,14 +271,7 @@ else
   echo "$$" > "${PIDFILE}"
 fi
 
-if [[ -f "${CONFIGFILE}" ]]; then
-  source "${CONFIGFILE}"
-elif [[ "${CUSTOMCONFIG}" ]]; then
-  logit "ERROR: Custom config file ${CONFIGFILE} does not exist"
-  quit 5
-else
-  logit "WARNING: Using default config values."
-fi
+read_config
 
 # CONFIGSET needs to be set if we're using a custom configuration file.
 if [[ -z "${CONFIGSET}" ]]; then

--- a/auter.aptModule
+++ b/auter.aptModule
@@ -26,8 +26,8 @@ function prepare_updates() {
     if [[ $(man "${PACKAGE_MANAGER}" | grep -c download-only) -gt 0 ]]; then
       ${PACKAGE_MANAGER} update &>/dev/null
       # Check if there are any errors when checking for updates
-      local ERROR_COUNT=$("${PACKAGE_MANAGER}" -u upgrade --assume-no "${PACKAGEMANAGEROPTIONS}" | grep -c '^[WE]:')
-      local AVAILABLE_PACKAGE_COUNT=$("${PACKAGE_MANAGER}" -u upgrade --assume-no "${PACKAGEMANAGEROPTIONS}" | awk '/upgraded,.*newly installed,/ {sum=$1+$3} END {print sum}')
+      local ERROR_COUNT=$($PACKAGE_MANAGER -u upgrade --assume-no $PACKAGEMANAGEROPTIONS | grep -c '^[WE]:')
+      local AVAILABLE_PACKAGE_COUNT=$($PACKAGE_MANAGER -u upgrade --assume-no $PACKAGEMANAGEROPTIONS | awk '/upgraded,.*newly installed,/ {sum=$1+$3} END {print sum}')
 
       if [[ ${ERROR_COUNT} -eq 0 ]]; then
         # If there are packages to be installed then download them.
@@ -40,7 +40,7 @@ function prepare_updates() {
             DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
           fi
           declare -x DEBIAN_FRONTEND=noninteractive
-          PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS}" "${DOWNLOADOPTION}" --download-only dist-upgrade -y 2>&1)
+          PREPOUTPUT=$($PACKAGE_MANAGER $PACKAGEMANAGEROPTIONS $DOWNLOADOPTION --download-only dist-upgrade -y 2>&1)
           if [[ $(echo "${PREPOUTPUT}" | grep -c '^[WE]:') -gt 0 ]]; then
             logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} --download-only dist-upgrade -y\`. Exiting."
           else

--- a/auter.aptModule
+++ b/auter.aptModule
@@ -26,8 +26,8 @@ function prepare_updates() {
     if [[ $(man "${PACKAGE_MANAGER}" | grep -c download-only) -gt 0 ]]; then
       ${PACKAGE_MANAGER} update &>/dev/null
       # Check if there are any errors when checking for updates
-      local ERROR_COUNT=$($PACKAGE_MANAGER -u upgrade --assume-no $PACKAGEMANAGEROPTIONS | grep -c '^[WE]:')
-      local AVAILABLE_PACKAGE_COUNT=$($PACKAGE_MANAGER -u upgrade --assume-no $PACKAGEMANAGEROPTIONS | awk '/upgraded,.*newly installed,/ {sum=$1+$3} END {print sum}')
+      local ERROR_COUNT=$("${PACKAGE_MANAGER}" -u upgrade --assume-no "${PACKAGEMANAGEROPTIONS[@]}" | grep -c '^[WE]:')
+      local AVAILABLE_PACKAGE_COUNT=$("${PACKAGE_MANAGER}" -u upgrade --assume-no "${PACKAGEMANAGEROPTIONS[@]}" | awk '/upgraded,.*newly installed,/ {sum=$1+$3} END {print sum}')
 
       if [[ ${ERROR_COUNT} -eq 0 ]]; then
         # If there are packages to be installed then download them.
@@ -42,7 +42,7 @@ function prepare_updates() {
           declare -x DEBIAN_FRONTEND=noninteractive
           PREPOUTPUT=$($PACKAGE_MANAGER $PACKAGEMANAGEROPTIONS $DOWNLOADOPTION --download-only dist-upgrade -y 2>&1)
           if [[ $(echo "${PREPOUTPUT}" | grep -c '^[WE]:') -gt 0 ]]; then
-            logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} --download-only dist-upgrade -y\`. Exiting."
+            logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS[@]} ${DOWNLOADOPTION} --download-only dist-upgrade -y\`. Exiting."
           else
             logit "INFO: Updates downloaded${DOWNLOADLOGMSG}"
           fi
@@ -50,13 +50,13 @@ function prepare_updates() {
           logit "INFO: No updates are available to be downloaded."
         fi
       else
-        logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS}\`. Exiting."
+        logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS[@]}\`. Exiting."
       fi
     else
       logit "WARNING: downloadonly option is not available"
     fi
   else
-    PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS}" -s dist-upgrade 2>&1)
+    PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" -s dist-upgrade 2>&1)
   fi
   rotate_file "${DATADIR}/last-prep-output-${CONFIGSET}"
   [[ "${PREPOUTPUT}" ]] && echo "${PREPOUTPUT}" >" ${DATADIR}/last-prep-output-${CONFIGSET}"
@@ -72,7 +72,7 @@ function apply_updates() {
   # Set the list of debs to be installed
   if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
     if [[ $(find "${DOWNLOADDIR}/${CONFIGSET}" -name "*.deb" | wc -l) -gt 0 ]]; then
-      local AVAILABLE_PACKAGES=$("${PACKAGE_MANAGER}" -u --just-print install --assume-no "${PACKAGEMANAGEROPTIONS}" "${DOWNLOADDIR}/${CONFIGSET}"/*.deb 2>&1)
+      local AVAILABLE_PACKAGES=$("${PACKAGE_MANAGER}" -u --just-print install --assume-no "${PACKAGEMANAGEROPTIONS[@]}" "${DOWNLOADDIR}/${CONFIGSET}"/*.deb 2>&1)
       echo "${AVAILABLE_PACKAGES}" >"${DATADIR}/last-apply-output-${CONFIGSET}"
       local AVAILABLE_PACKAGE_COUNT=$(echo "${AVAILABLE_PACKAGES}" | awk '/upgraded,.*newly installed,/ {sum=$1+$3} END {print sum}')
       DEBS="${DOWNLOADDIR}/${CONFIGSET}/*.deb"
@@ -84,7 +84,7 @@ function apply_updates() {
     # installed (i.e. dependencies of other packages). Instead we need to use install.
     UPDATEACTION="install"
   else
-    local AVAILABLE_PACKAGES=$(${PACKAGE_MANAGER} -u upgrade --assume-no "${PACKAGEMANAGEROPTIONS}" 2>&1)
+    local AVAILABLE_PACKAGES=$(${PACKAGE_MANAGER} -u upgrade --assume-no "${PACKAGEMANAGEROPTIONS[@]}" 2>&1)
     echo "${AVAILABLE_PACKAGES}" >"${DATADIR}/last-apply-output-${CONFIGSET}"
     local ERROR_COUNT=$(echo "${AVAILABLE_PACKAGES}" | grep -c '^[WE]:')
     local AVAILABLE_PACKAGE_COUNT=$(echo "${AVAILABLE_PACKAGES}" | awk '/upgraded,.*newly installed,/ {sum=$1+$3} END {print sum}')
@@ -104,7 +104,7 @@ function apply_updates() {
       # We don't want to allow the user to interrupt a yum/dnf/apt transaction or Bad Things Happen.
       echo "Trying to update"
       trap '' SIGINT SIGTERM
-      RUN_OUTPUT=$("${PACKAGE_MANAGER}" "${UPDATEACTION}" "${PACKAGEMANAGEROPTIONS}" "${DEBS}")
+      RUN_OUTPUT=$("${PACKAGE_MANAGER}" "${UPDATEACTION}" "${PACKAGEMANAGEROPTIONS[@]}" "${DEBS}")
       rotate_file "${DATADIR}/last-apply-output-${CONFIGSET}"
       echo "${RUN_OUTPUT}" &>"${DATADIR}/last-apply-output-${CONFIGSET}"
       default_signal_handling
@@ -130,7 +130,7 @@ function apply_updates() {
       log_last_run
     fi
   else
-    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS}\`. Exiting."
+    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS[@]}\`. Exiting."
     quit 3
   fi
 }

--- a/auter.aptModule
+++ b/auter.aptModule
@@ -40,9 +40,9 @@ function prepare_updates() {
             DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
           fi
           declare -x DEBIAN_FRONTEND=noninteractive
-          PREPOUTPUT=$($PACKAGE_MANAGER $PACKAGEMANAGEROPTIONS $DOWNLOADOPTION --download-only dist-upgrade -y 2>&1)
+          PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" "${DOWNLOADOPTION}" --download-only dist-upgrade -y 2>&1)
           if [[ $(echo "${PREPOUTPUT}" | grep -c '^[WE]:') -gt 0 ]]; then
-            logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS[@]} ${DOWNLOADOPTION} --download-only dist-upgrade -y\`. Exiting."
+            logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS[*]} ${DOWNLOADOPTION} --download-only dist-upgrade -y\`. Exiting."
           else
             logit "INFO: Updates downloaded${DOWNLOADLOGMSG}"
           fi
@@ -50,7 +50,7 @@ function prepare_updates() {
           logit "INFO: No updates are available to be downloaded."
         fi
       else
-        logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS[@]}\`. Exiting."
+        logit "ERROR: There were errors returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS[*]}\`. Exiting."
       fi
     else
       logit "WARNING: downloadonly option is not available"
@@ -130,7 +130,7 @@ function apply_updates() {
       log_last_run
     fi
   else
-    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS[@]}\`. Exiting."
+    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} -u upgrade --assume-no ${PACKAGEMANAGEROPTIONS[*]}\`. Exiting."
     quit 3
   fi
 }

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -42,26 +42,26 @@ function prepare_updates() {
   done
 
   if [[ "${PREDOWNLOADUPDATES}" == "yes" ]]; then
-    if [[ $(${PACKAGE_MANAGER} --help | grep -c downloadonly) -gt 0 ]]; then
-      local RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS}" &>/dev/null; echo $?)
+    if [[ $("${PACKAGE_MANAGER}" --help | grep -c downloadonly) -gt 0 ]]; then
+      local RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS[@]}" &>/dev/null; echo $?)
 
       # If check-update has an exit code of 100, updates are available.
       if [[ "${RC}" -eq 100 ]]; then
         # Run any pre-prep scripts
         sleep $((RANDOM % MAXDELAY))
         if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
-          DOWNLOADOPTION="--downloaddir=${DOWNLOADDIR}/${CONFIGSET}"
+          DOWNLOADOPTION=("--downloaddir=${DOWNLOADDIR}/${CONFIGSET}")
           rm -f "${DOWNLOADDIR}"/"${CONFIGSET}"/*.rpm
           # DNF doesn't support downloaddir, so instead we download to the default
           # location and copy out the way
           if [[ "${PACKAGE_MANAGER}" == "dnf" ]]; then
             find /var/cache/dnf -name "*.rpm" -exec rm -f {} \;
-            DOWNLOADOPTION=""
+            DOWNLOADOPTION=()
           fi
           DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
         fi
 
-        PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS}" "${DOWNLOADOPTION}" update --downloadonly -y 2>&1)
+        PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" "${DOWNLOADOPTION[@]}" update --downloadonly -y 2>&1)
         if [[ $? -eq 0 ]]; then
           if [[ "${ONLYINSTALLFROMPREP}" == "yes" && "${PACKAGE_MANAGER}" == "dnf" ]]; then
             find /var/cache/dnf -name "*.rpm" -exec mv {} "${DOWNLOADDIR}/${CONFIGSET}" \;
@@ -72,7 +72,7 @@ function prepare_updates() {
         fi
 
       elif [[ "${RC}" -eq 1 ]]; then
-        logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS} ${DOWNLOADOPTION} update --downloadonly -y\`. Exiting."
+        logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS[@]} ${DOWNLOADOPTION[@]} update --downloadonly -y\`. Exiting."
       else
         logit "INFO: No updates are available to be downloaded."
       fi
@@ -80,7 +80,7 @@ function prepare_updates() {
       logit "WARNING: downloadonly option is not available"
     fi
   else
-    PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS}" check-update 2>&1)
+    PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" check-update 2>&1)
   fi
   rotate_file "${DATADIR}/last-prep-output-${CONFIGSET}"
   [[ "${PREPOUTPUT}" ]] && echo "${PREPOUTPUT}" > "${DATADIR}/last-prep-output-${CONFIGSET}"
@@ -116,7 +116,7 @@ function apply_updates() {
     # installed (i.e. dependencies of other packages). Instead we need to use install.
     UPDATEACTION="install"
   else
-    local RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS}" &>/dev/null; echo $?)
+    local RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS[@]}" &>/dev/null; echo $?)
     UPDATEACTION="update"
   fi
 
@@ -136,7 +136,7 @@ function apply_updates() {
     # We don't want to allow the user to interrupt a yum/dnf transaction or Bad Things Happen.
     trap '' SIGINT SIGTERM
     rotate_file "${DATADIR}/last-apply-output-${CONFIGSET}"
-    "${PACKAGE_MANAGER}" "${UPDATEACTION}" -y "${PACKAGEMANAGEROPTIONS}" "${RPMS}" &>"${DATADIR}/last-apply-output-${CONFIGSET}"
+    "${PACKAGE_MANAGER}" "${UPDATEACTION}" -y "${PACKAGEMANAGEROPTIONS[@]}" "${RPMS}" &>"${DATADIR}/last-apply-output-${CONFIGSET}"
     default_signal_handling
 
     local HISTORY_AFTER=$(${PACKAGE_MANAGER} history list)
@@ -161,7 +161,7 @@ function apply_updates() {
     logit "INFO: No updates are available to be applied."
     log_last_run
   else
-    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS}\`. Exiting."
+    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS[@]}\`. Exiting."
     quit 3
   fi
 }

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -72,7 +72,7 @@ function prepare_updates() {
         fi
 
       elif [[ "${RC}" -eq 1 ]]; then
-        logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS[@]} ${DOWNLOADOPTION[@]} update --downloadonly -y\`. Exiting."
+        logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} ${PACKAGEMANAGEROPTIONS[*]} ${DOWNLOADOPTION[*]} update --downloadonly -y\`. Exiting."
       else
         logit "INFO: No updates are available to be downloaded."
       fi
@@ -161,7 +161,7 @@ function apply_updates() {
     logit "INFO: No updates are available to be applied."
     log_last_run
   else
-    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS[@]}\`. Exiting."
+    logit "ERROR: Exit status ${RC} returned by \`${PACKAGE_MANAGER} check-update ${PACKAGEMANAGEROPTIONS[*]}\`. Exiting."
     quit 3
   fi
 }


### PR DESCRIPTION
Wrapping `${PACKAGEMANAGEROPTIONS}` with the double quotes causes it to expand to `''` when `$PACKAGEMANAGEROPTIONS` is empty. This is causing yum to run the following:

```
yum check-update ''
```

which always returns 0 for no updates:

```
root@centos6:~ > auter --prep
INFO: Running with: /usr/bin/auter --prep
INFO: Running in an interactive shell, disabling all random sleeps
INFO: Running Pre-Prep script /etc/auter/pre-prep.d/pre_prep_script
++ yum check-update ''
++ echo 0
+ local RC=0
+ set +x
INFO: No updates are available to be downloaded.
INFO: Running Post-Prep script /etc/auter/post-prep.d/post_prep_script
root@centos6:~ >
root@centos6:~ > yum -q check-update

httpd.x86_64                                                               2.2.15-60.el6.centos.6                                                       updates
httpd-tools.x86_64                                                         2.2.15-60.el6.centos.6                                                       updates
kernel.x86_64                                                              2.6.32-696.23.1.el6                                                          updates
kernel-firmware.noarch                                                     2.6.32-696.23.1.el6                                                          updates
libgcc.x86_64                                                              4.4.7-18.el6_9.2                                                             updates
libstdc++.x86_64                                                           4.4.7-18.el6_9.2                                                             updates
nova-agent.noarch                                                          2.1.12-1.el6                                                                 epel
qemu-img.x86_64                                                            2:0.12.1.2-2.503.el6_9.5                                                     updates

```