### PR TITLE
Log auter prep even when there are no updates available

### DIFF
--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -35,8 +35,8 @@ function check_package_manager_lock() {
 function prepare_updates() {
   # Check for yum.lock file
   check_package_manager_lock
-  local PREPOUTPUT
-  local -i RC
+  declare PREPOUTPUT
+  declare -i RC
 
   PREPOUTPUT="$(date '+%F %T')\\n"
   # Run any pre-prep scripts
@@ -87,7 +87,7 @@ function prepare_updates() {
       logit "WARNING: downloadonly option is not available"
     fi
   else
-    PREPOUTPUT+=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" check-update 2>&1)
+    PREPOUTPUT+="$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" check-update 2>&1)"
   fi
   rotate_file "${DATADIR}/last-prep-output-${CONFIGSET}"
   [[ "${PREPOUTPUT}" ]] && echo -e "${PREPOUTPUT}" > "${DATADIR}/last-prep-output-${CONFIGSET}"
@@ -100,12 +100,12 @@ function prepare_updates() {
 
 function apply_updates() {
   # Default RC to 0 which means no updates are available
-  local -i RC=0
-  local APPLYOUTPUT
-  local UPDATEACTION
-  local HISTORY_BEFORE
-  local HISTORY_AFTER
-  local TRANSACTIONID
+  declare -i RC=0
+  declare APPLYOUTPUT
+  declare UPDATEACTION
+  declare HISTORY_BEFORE
+  declare HISTORY_AFTER
+  declare TRANSACTIONID
 
   APPLYOUTPUT="$(date '+%F %T')\\n"
   # Set the list of rpms to be installed

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -35,7 +35,10 @@ function check_package_manager_lock() {
 function prepare_updates() {
   # Check for yum.lock file
   check_package_manager_lock
+  local PREPOUTPUT
+  local -i RC
 
+  PREPOUTPUT="$(date '+%F %T')\\n"
   # Run any pre-prep scripts
   for SCRIPT in "${PREPREPSCRIPTDIR}"/*; do
     run_script "${SCRIPT}" "Pre-Prep"
@@ -46,7 +49,8 @@ function prepare_updates() {
       # Remove the old RPMS from the auter cache
       [[ "${ONLYINSTALLFROMPREP}" == "yes" ]] && rm -f "${DOWNLOADDIR}"/"${CONFIGSET}"/*.rpm
 
-      local RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS[@]}" &>/dev/null; echo $?)
+      PREPOUTPUT+=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS[@]}")
+      RC=$?
 
       # If check-update has an exit code of 100, updates are available.
       if [[ "${RC}" -eq 100 ]]; then
@@ -64,8 +68,8 @@ function prepare_updates() {
           DOWNLOADLOGMSG=" to ${DOWNLOADDIR}/${CONFIGSET}"
         fi
 
-        PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" "${DOWNLOADOPTION[@]}" update --downloadonly -y 2>&1)
-        if [[ $? -eq 0 ]]; then
+        
+        if PREPOUTPUT+="$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" "${DOWNLOADOPTION[@]}" update --downloadonly -y 2>&1)"; then
           if [[ "${ONLYINSTALLFROMPREP}" == "yes" && "${PACKAGE_MANAGER}" == "dnf" ]]; then
             find /var/cache/dnf -name "*.rpm" -exec mv {} "${DOWNLOADDIR}/${CONFIGSET}" \;
           fi
@@ -83,10 +87,10 @@ function prepare_updates() {
       logit "WARNING: downloadonly option is not available"
     fi
   else
-    PREPOUTPUT=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" check-update 2>&1)
+    PREPOUTPUT+=$("${PACKAGE_MANAGER}" "${PACKAGEMANAGEROPTIONS[@]}" check-update 2>&1)
   fi
   rotate_file "${DATADIR}/last-prep-output-${CONFIGSET}"
-  [[ "${PREPOUTPUT}" ]] && echo "${PREPOUTPUT}" > "${DATADIR}/last-prep-output-${CONFIGSET}"
+  [[ "${PREPOUTPUT}" ]] && echo -e "${PREPOUTPUT}" > "${DATADIR}/last-prep-output-${CONFIGSET}"
 
   # Run any post-prep scripts
   for SCRIPT in "${POSTPREPSCRIPTDIR}"/*; do
@@ -95,10 +99,17 @@ function prepare_updates() {
 }
 
 function apply_updates() {
+  # Default RC to 0 which means no updates are available
+  local -i RC=0
+  local APPLYOUTPUT
+  local UPDATEACTION
+  local HISTORY_BEFORE
+  local HISTORY_AFTER
+  local TRANSACTIONID
+
+  APPLYOUTPUT="$(date '+%F %T')\\n"
   # Set the list of rpms to be installed
   if [[ "${ONLYINSTALLFROMPREP}" == "yes" ]]; then
-    # Default RC to 0 which means no updates are available
-    local RC=0
     # Check if there are updates staged for this configset
     if [[ $(find "${DOWNLOADDIR}/${CONFIGSET}" -name "*.rpm" | wc -l) -gt 0 ]]; then
       local RPMS=()
@@ -119,7 +130,7 @@ function apply_updates() {
     # installed (i.e. dependencies of other packages). Instead we need to use install.
     UPDATEACTION="install"
   else
-    local RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS[@]}" &>/dev/null; echo $?)
+    RC=$("${PACKAGE_MANAGER}" check-update "${PACKAGEMANAGEROPTIONS[@]}" &>/dev/null; echo $?)
     UPDATEACTION="update"
   fi
 
@@ -134,15 +145,16 @@ function apply_updates() {
 
     sleep $((RANDOM % MAXDELAY))
     logit "INFO: Applying updates"
-    local HISTORY_BEFORE=$(${PACKAGE_MANAGER} history list)
+    HISTORY_BEFORE=$(${PACKAGE_MANAGER} history list)
 
     # We don't want to allow the user to interrupt a yum/dnf transaction or Bad Things Happen.
     trap '' SIGINT SIGTERM
     rotate_file "${DATADIR}/last-apply-output-${CONFIGSET}"
-    "${PACKAGE_MANAGER}" "${UPDATEACTION}" -y "${PACKAGEMANAGEROPTIONS[@]}" "${RPMS[@]}" &>"${DATADIR}/last-apply-output-${CONFIGSET}"
+    APPLYOUTPUT=$("${PACKAGE_MANAGER}" "${UPDATEACTION}" -y "${PACKAGEMANAGEROPTIONS[@]}" "${RPMS[@]}")
     default_signal_handling
+    echo -e "$APPLYOUTPUT" &>"${DATADIR}/last-apply-output-${CONFIGSET}"
 
-    local HISTORY_AFTER=$(${PACKAGE_MANAGER} history list)
+    HISTORY_AFTER=$(${PACKAGE_MANAGER} history list)
 
     for SCRIPT in "${POSTAPPLYSCRIPTDIR}"/*; do
       run_script "${SCRIPT}" "Post-Apply"
@@ -154,7 +166,7 @@ function apply_updates() {
       quit 3
     fi
 
-    local TRANSACTIONID=$(${PACKAGE_MANAGER} history info 2>&1 | grep "Transaction ID")
+    TRANSACTIONID=$(${PACKAGE_MANAGER} history info 2>&1 | grep "Transaction ID")
     logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
     log_last_run
 


### PR DESCRIPTION
For rackerlabs/auter/issues/133.

Always log the prep output regardless of whether there were any package updates. This PR also add a date stamp to the top of the file to make it clear which prep/apply the output file is for.