### PR TITLE
Fix auto-reboot not working

### DIFF
--- a/auter
+++ b/auter
@@ -27,6 +27,7 @@ declare -r -x PIDFILE="/var/run/auter/auter.pid"
 
 # Set default options - these can be overridden in the config file or with a command line argument
 declare -x -l AUTOREBOOT="no"
+declare -x -i REBOOTCALL=0
 declare -x -a PACKAGEMANAGEROPTIONS
 declare -x -l PREDOWNLOADUPDATES="yes"
 declare -x -l ONLYINSTALLFROMPREP="no"
@@ -305,6 +306,6 @@ tty -s && MAXDELAY=1 && logit "INFO: Running in an interactive shell, disabling 
 [[ "${PREP}" ]] && prepare_updates
 [[ "${APPLY}" ]] && apply_updates
 
-[[ "${REBOOTCALL}" ]] && reboot_server
+[[ $REBOOTCALL -eq 1 ]] && reboot_server
 
 quit 0

--- a/auter.yumdnfModule
+++ b/auter.yumdnfModule
@@ -155,7 +155,8 @@ function apply_updates() {
     logit "INFO: Updates complete (${PACKAGE_MANAGER} ${TRANSACTIONID}). You may need to reboot for some updates to take effect"
     log_last_run
 
-    [[ "${AUTOREBOOT}" == "yes" ]] && declare -x REBOOTCALL=1
+    # shellcheck disable=SC2034
+    [[ "${AUTOREBOOT}" == "yes" ]] && REBOOTCALL=1
 
   elif [[ "${RC}" -eq 0 ]]; then
     logit "INFO: No updates are available to be applied."


### PR DESCRIPTION
AUTOREBOOT="yes" is not working due to the REBOOTCALL variable being
declared in the apply_update function.

This moves the REBOOTCALL declaration to the start of the main auter
script and removes the declare from within the function. We maintain the
default no auto-reboot, however the global variable is now updated
correctly.