### PR TITLE
Remove output files greater than the ROTATE value

### DIFF
--- a/auter
+++ b/auter
@@ -91,9 +91,10 @@ function read_config() {
 }
 
 function rotate_file {
+  declare OUTPUT_FILE="$1"
+  declare -a REMOVE_FILES
+
   #Rotate old file
-  local OUTPUT_FILE="$1"
-  local -a REMOVE_FILES
   for i in $(seq $((ROTATE-1)) -1 1); do
     [[ -e "${OUTPUT_FILE}.$i" ]] && mv -f "${OUTPUT_FILE}.$i" "${OUTPUT_FILE}.$((i+1))"
   done

--- a/auter
+++ b/auter
@@ -92,7 +92,8 @@ function read_config() {
 
 function rotate_file {
   #Rotate old file
-  OUTPUT_FILE=$1
+  local OUTPUT_FILE="$1"
+  local -a REMOVE_FILES
   for i in $(seq $((ROTATE-1)) -1 1); do
     [[ -e "${OUTPUT_FILE}.$i" ]] && mv -f "${OUTPUT_FILE}.$i" "${OUTPUT_FILE}.$((i+1))"
   done
@@ -100,8 +101,9 @@ function rotate_file {
   # Move base files to basefile.1
   [[ -e "${OUTPUT_FILE}" ]] && mv "${OUTPUT_FILE}" "${OUTPUT_FILE}.1"
 
+  readarray -t REMOVE_FILES <<< "$(find "$DATADIR" -type f -name "$(basename "$OUTPUT_FILE").*" | awk -F'.' -v s="$ROTATE" '($NF+1)>s')"
   # Finally check for extra file from the rotation, and remove if it exists
-  [[ -e "${OUTPUT_FILE}.${ROTATE}" ]] && rm -f "${OUTPUT_FILE}.${ROTATE}"
+  [[ -n "${REMOVE_FILES[*]}" ]] && rm -f "${REMOVE_FILES[@]}"
 }
 
 function run_script {


### PR DESCRIPTION
If the ROTATE value is reduced then we need to clean up the old files
with indexes greater than ROTATE.