### PR TITLE
Build mandb during install/uninstall

### DIFF
--- a/auter.spec
+++ b/auter.spec
@@ -65,15 +65,23 @@ chmod 0755 %{buildroot}%{_sysconfdir}/%{name}/*.d
 # If this is the first time install, create the lockfile
 if [ $1 -eq 1 ]; then
   /usr/bin/auter --enable
+  mandb -q
 fi
 exit 0
 
 %preun
 # If this is a complete removal, then remove lockfile
 if [ $1 -eq 0 ]; then
- /usr/bin/auter --disable
+  /usr/bin/auter --disable
 fi
 exit 0
+
+%postun
+if [ $1 -eq 0 ]; then
+  mandb -q
+fi
+exit 0
+
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
`man -k auter` wasn't showing the new auter.conf.man file post install.
It's probably a good idea to update the mandb during the
install/uninstall process to make sure man pages are searchable/removed
respectively.