### PR TITLE
lsof fix for RHEL/CentOS 6

### DIFF
--- a/contrib/conditionalReboot/99-conditionalReboot.sh
+++ b/contrib/conditionalReboot/99-conditionalReboot.sh
@@ -64,9 +64,13 @@ if [[ "${DISTRIBUTION}" =~ CentOS|Red\ Hat|Fedora|Oracle\ Linux ]]; then
   fi
 fi
 
-# Identify if there are any libraries that are running but deleted
-LIBCHECK=$(PATH=/usr/sbin:/usr/local/sbin:$PATH lsof | grep lib | grep DEL)
-[[ -n "${LIBCHECK}" ]] && REBOOTREQURIRED+=("detected deleted libraries")
+# If lsof is installed, Identify if there are any libraries that are running but deleted
+if LSOFEXEC="$(PATH=/usr/sbin:/usr/local/sbin:$PATH which lsof 2>/dev/null)"; then
+  LIBCHECK=$(${LSOFEXEC} | grep lib | grep DEL)
+  [[ -n "${LIBCHECK}" ]] && REBOOTREQURIRED+=("detected deleted libraries")
+else
+  logit "$0 - lsof not found: unable to check running libraries"
+fi
 
 # Check if any of the packages in the APPLIST were updated
 if [[ -n ${APPLIST} ]]; then

--- a/contrib/conditionalReboot/README.md
+++ b/contrib/conditionalReboot/README.md
@@ -9,7 +9,7 @@ This script will assess the running distribution and do some basic checks to ass
 Language: BASH
 Supported OS: CENTOS>=6 RHEL>=6 Fedora>=26 Ubuntu>=16.04 Debian>=9
 Additional setup required: NO
-Dependencies: python 
+Dependencies: python, lsof
 
 
 # Description


### PR DESCRIPTION
Resolves #171 
1) Added lsof as a dependency in README.md.
2) Added a check that lsof executable exists