### PR TITLE
REBOOTCALL is now 0 by default so the test is failing

### DIFF
--- a/auter
+++ b/auter
@@ -232,7 +232,7 @@ while true ; do
   esac
 done
 
-[[ "${PREP}${APPLY}${REBOOTCALL}${POSTREBOOT}${ENABLE}${DISABLE}" == "" ]] && print_help && quit 1
+[[ ! "$ARGS" =~ prep|apply|reboot|postreboot|enable|disable  ]] && print_help && quit 1
 
 readonly PACKAGE_MANAGER=$(check_package_manager)
 

--- a/auter
+++ b/auter
@@ -232,7 +232,7 @@ while true ; do
   esac
 done
 
-[[ ! "$ARGS" =~ prep|apply|reboot|postreboot|enable|disable  ]] && print_help && quit 1
+[[ ! "$ARGS" =~ --(prep|apply|reboot|postreboot|enable|disable)  ]] && print_help && quit 1
 
 readonly PACKAGE_MANAGER=$(check_package_manager)
 


### PR DESCRIPTION
Resolves #181.

Swap the string check for a simple arg count check. When no args, run
print_help and exit.