### PR TITLE
auter.conf man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ deb:
 	@rm -f ${pkg_name}-${version}/LICENSE
 	@mkdir ${pkg_name}-${version}/docs
 	@/usr/bin/help2man --section=1 ./auter -N -o ${pkg_name}-${version}/docs/auter.1 -n "Automatic Update Transaction Execution by Rackspace" --include=auter.help2man-sections
+	@mv ${pkg_name}-${version}/auter.conf.man ${pkg_name}-${version}/docs/auter.conf.5
 	@echo "auter (${version}) ${distributionrelease}; urgency=medium" >${pkg_name}-${version}/debian/changelog
 	@echo "  * Release ${version}." >>${pkg_name}-${version}/debian/changelog
 	# DON'T FORGET TO CHANGE THIS VERSION AT NEXT RELEASE

--- a/auter.conf.man
+++ b/auter.conf.man
@@ -1,4 +1,4 @@
-.TH AUTER.CONF "8" "May 2018" "auter 0.11" "File Formats"
+.TH AUTER.CONF "5" "May 2018" "auter 0.11" "File Formats"
 .SH NAME
 auter.conf \- Config file for auter
 .SH SYNOPSIS

--- a/auter.spec
+++ b/auter.spec
@@ -43,7 +43,7 @@ mkdir -p %{buildroot}%{_bindir} %{buildroot}%{_sharedstatedir}/%{name} \
   %{buildroot}%{_var}/cache/auter \
   %{buildroot}%{_usr}/lib/%{name} \
   %{buildroot}%{_mandir}/man1 \
-  %{buildroot}%{_mandir}/man8 \
+  %{buildroot}%{_mandir}/man5 \
   %{buildroot}%{_sysconfdir}/%{name}/pre-reboot.d \
   %{buildroot}%{_sysconfdir}/%{name}/post-reboot.d \
   %{buildroot}%{_sysconfdir}/%{name}/pre-apply.d \
@@ -56,7 +56,7 @@ install -p -m 0755 %{name}.yumdnfModule %{buildroot}%{_usr}/lib/%{name}/auter.mo
 install -p -m 0644 %{name}.cron %{buildroot}%{_sysconfdir}/cron.d/%{name}
 install -p -m 0644 %{name}.conf %{buildroot}%{_sysconfdir}/%{name}/%{name}.conf
 install -p -m 0644 %{name}.man %{buildroot}%{_mandir}/man1/%{name}.1
-install -p -m 0644 %{name}.conf.man %{buildroot}%{_mandir}/man8/%{name}.conf.8
+install -p -m 0644 %{name}.conf.man %{buildroot}%{_mandir}/man5/%{name}.conf.5
 chmod 0755 %{buildroot}%{_sysconfdir}/%{name}/*.d
 
 %post
@@ -80,7 +80,7 @@ exit 0
 %doc NEWS
 %doc MAINTAINERS.md
 %{_mandir}/man1/%{name}.1*
-%{_mandir}/man8/%{name}.conf.8*
+%{_mandir}/man5/%{name}.conf.5*
 %{_sharedstatedir}/%{name}
 %dir %{_sysconfdir}/%{name}
 %dir %{_var}/cache/auter

--- a/debian/auter.manpages
+++ b/debian/auter.manpages
@@ -1,1 +1,2 @@
 docs/auter.1
+docs/auter.conf.5


### PR DESCRIPTION
- Added config to create man page for auter.conf. 
- Also adjusted that man page to be a man5 page not man8 (as per man man):
```
       1   Executable programs or shell commands
       2   System calls (functions provided by the kernel)
       3   Library calls (functions within program libraries)
       4   Special files (usually found in /dev)
       5   File formats and conventions eg /etc/passwd
       6   Games
       7   Miscellaneous (including macro packages and conventions), e.g. man(7), groff(7)
       8   System administration commands (usually only for root)
       9   Kernel routines [Non standard]
```