### PR TITLE
Check getopt directly in if statement in auter script

### DIFF
--- a/auter
+++ b/auter
@@ -234,9 +234,7 @@ function print_status() {
 
 # Needed to cleanup our PID file. The only argument is the exit code to use.
 function quit() {
-  if [[ -f "${PIDFILE}" ]]; then
-    rm -f "${PIDFILE}"
-  fi
+  [[ -f "$PIDFILE" ]] && rm -f "$PIDFILE"
   exit "$1"
 }
 
@@ -251,13 +249,13 @@ function log_last_run() {
 default_signal_handling
 
 ARGS="$*"
-OPTS=$(getopt -n "$0" -o h,v --long prep,apply,enable,disable,reboot,postreboot,version,help,stdout,no-wall,status,config:,skip-all-scripts,skip-scripts-by-phase:,skip-scripts-by-name:,maxdelay: -- "$@")
-if [[ $? -ne 0 ]]; then
-  echo "Try '$0 --help' for more information."
-  exit
+if ! OPTS=$(getopt -n "$0" -o h,v --long prep,apply,enable,disable,reboot,postreboot,version,help,stdout,no-wall,status,config:,skip-all-scripts,skip-scripts-by-phase:,skip-scripts-by-name:,maxdelay: -- "$@"); then
+  echo "See '$0 --help' for valid options."
+  quit 1
 fi
 
 eval set -- "$OPTS"
+unset OPTS
 
 while true ; do
   case "$1" in
@@ -276,7 +274,7 @@ while true ; do
     --skip-all-scripts) SKIPALLSCRIPTS=1 ; shift;;
     --skip-scripts-by-phase) IFS=',' read -r -a SKIPPHASESCRIPTS <<< "$2" ; shift 2;;
     --skip-scripts-by-name) IFS=',' read -r -a SKIPSCRIPTNAMES <<< "$2" ; shift 2;;
-    --status) print_status ; exit 0;;
+    --status) print_status ; quit 0;;
     --) shift ; break;;
   esac
 done


### PR DESCRIPTION
Resolves a ShellCheck warning about checking return codes after assignment.

Also replace some exits with quits.