### PR TITLE
Loop through package managers

### DIFF
--- a/auter
+++ b/auter
@@ -176,16 +176,11 @@ function run_script {
 
 # Check whether yum, or dnf is available
 function check_package_manager() {
-  if [[ -x /usr/bin/dnf ]]; then
-    echo dnf
-  elif [[ -x /usr/bin/yum ]]; then
-    echo yum
-  elif [[ -x /usr/bin/apt-get ]]; then
-    echo apt-get
-  else
-    logit "ERROR: Cannot find yum, dnf or apt-get"
-    exit 7
-  fi
+  for pkg_mgr in dnf yum apt-get; do
+    command -v "$pkg_mgr" && return 0
+  done
+  logit "ERROR: Cannot find yum, dnf or apt-get"
+  exit 7
 }
 
 function reboot_server() {

--- a/auter
+++ b/auter
@@ -179,8 +179,7 @@ function check_package_manager() {
   for pkg_mgr in dnf yum apt-get; do
     command -v "$pkg_mgr" && return 0
   done
-  logit "ERROR: Cannot find yum, dnf or apt-get"
-  exit 7
+  return 1
 }
 
 function reboot_server() {
@@ -349,7 +348,7 @@ if ! $_required; then
 fi
 unset _required
 
-readonly PACKAGE_MANAGER=$(check_package_manager)
+if ! PACKAGE_MANAGER=$(check_package_manager); then logit "ERROR: Cannot find yum, dnf or apt-get"; quit 7; fi
 
 # Do this after option processing so --help and --status still work.
 if [[ "$(whoami)" != "root" ]]; then

--- a/auter
+++ b/auter
@@ -348,6 +348,7 @@ if ! $_required; then
 fi
 unset _required
 
+declare -x PACKAGE_MANAGER
 if ! PACKAGE_MANAGER=$(check_package_manager); then logit "ERROR: Cannot find yum, dnf or apt-get"; quit 7; fi
 
 # Do this after option processing so --help and --status still work.


### PR DESCRIPTION
Cycle through the package manage list until a match is found, then
return full path to executable using 'command -v'.